### PR TITLE
Fix: Fixed typo on readme on get customers by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,10 @@ To run an "All-Nest" configuration &#8212; that is, the **Nest requestor** (_nes
 
    ```json
    {
-     "customers": [
-       {
-         "id": 1,
-         "name": "nestjs.com"
-       }
-     ]
+     "customers": {
+       "id": 1,
+       "name": "nestjs.com"
+     }
    }
    ```
 


### PR DESCRIPTION
Fixed typo on readme for get customers by id  `http get localhost:3000/customers/1`